### PR TITLE
fix(#20): Basic Simulation (No Outlets)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
     { name = "JohnRushKucharski", email = "johnkucharski@gmail.com" }
 ]
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "numpy>=2.4.4",
+]
 
 [project.optional-dependencies]
 units = [

--- a/src/canteen/__init__.py
+++ b/src/canteen/__init__.py
@@ -36,6 +36,19 @@ Basic Usage
     # Operate the reservoir
     spill = res.operate(inflow=50.0)
 
+Simulation
+----------
+    # Simulate reservoir over multiple timesteps
+    from canteen import simulate
+    import numpy as np
+    
+    res = reservoir.factory(name="Dam", storage=50.0, capacity=100.0)
+    inflows = [10.0, 20.0, 30.0, 15.0]
+    
+    results = simulate(res, inflows)
+    # results is a numpy structured array with columns:
+    # timestep, inflow, storage, spill
+
 Builder Pattern
 ---------------
     # Reservoirs support fluent builder pattern for incremental construction
@@ -97,6 +110,9 @@ from canteen.metadata import (
 from canteen.units import (
     Quantity
 )
+from canteen.simulation import (
+    simulate
+)
 
 __version__ = "0.1.0"
 __all__ = [
@@ -135,4 +151,7 @@ __all__ = [
     # Utility functions
     "build_interpolation_fx",
     "build_1D_interpolation_fxs",
+
+    # Simulation
+    "simulate",
 ]

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -1,0 +1,75 @@
+"""
+Simulation module for running reservoir operations over multiple timesteps.
+
+This module provides the orchestration layer that runs a reservoir through
+multiple timesteps given a sequence of inflows. Copies the reservoir internally,
+calls operate(inflow) for each timestep, and records storage and outflow states.
+"""
+
+from typing import Sequence, Any
+import copy
+import numpy as np
+from numpy.typing import NDArray
+
+from canteen.reservoir import Reservoir
+
+
+def simulate(
+    reservoir: Reservoir,
+    inflows: Sequence[float] | NDArray[np.floating[Any]],
+    timestamps: Sequence[Any] | None = None
+) -> NDArray[np.void]:
+    """
+    Simulate reservoir operations over multiple timesteps.
+
+    Copies the reservoir internally to preserve the original state, then runs
+    operate() for each inflow and records results.
+
+    Parameters
+    ----------
+    reservoir : Reservoir
+        The reservoir to simulate. Original instance is not modified.
+    inflows : Sequence[float] | NDArray[np.floating[Any]]
+        Volume of water entering the reservoir at each timestep. Can be negative
+        (evaporation is valid).
+    timestamps : Sequence[Any] | None
+        Optional timestamps for labeling results. Not required for execution.
+
+    Returns
+    -------
+    NDArray[np.void]
+        Structured array with columns: timestep (int), inflow (float),
+        storage (float), spill (float). Returns empty array with correct
+        dtype when inflows is empty.
+    """
+    # Define result dtype
+    dtype = np.dtype([
+        ('timestep', np.int32),
+        ('inflow', np.float64),
+        ('storage', np.float64),
+        ('spill', np.float64)
+    ])
+
+    # Handle empty inflows edge case
+    if len(inflows) == 0:
+        return np.array([], dtype=dtype)
+
+    # Copy reservoir to preserve original
+    res_copy = copy.deepcopy(reservoir)
+
+    # Pre-allocate result array
+    result = np.zeros(len(inflows), dtype=dtype)
+
+    # Simulate each timestep
+    for timestep, inflow in enumerate(inflows):
+        # Call operate to get outflows
+        outflows = res_copy.operate(inflow)
+
+        # Record results
+        result[timestep]['timestep'] = timestep
+        result[timestep]['inflow'] = inflow
+        result[timestep]['storage'] = res_copy.storage
+        # Spill is always the last element of outflows tuple
+        result[timestep]['spill'] = outflows[-1]
+
+    return result

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,129 @@
+"""Tests for simulation functionality."""
+
+import numpy as np
+
+from canteen import reservoir
+from canteen.simulation import simulate
+
+
+class TestSimulateBasics:
+    """Test basic simulation behavior."""
+
+    def test_simulate_accepts_reservoir_and_inflows(self):
+        """Test that simulate accepts a reservoir and inflows."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows = [10.0, 20.0, 15.0]
+
+        result = simulate(res, inflows)
+
+        # Should return something
+        assert result is not None
+
+    def test_simulate_returns_structured_array_with_correct_columns(self):
+        """Test that simulate returns numpy structured array with correct dtype."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows = [10.0, 20.0]
+
+        result = simulate(res, inflows)
+
+        # Check it's a numpy array
+        assert isinstance(result, np.ndarray)
+        # Check it has the right columns
+        assert 'timestep' in result.dtype.names
+        assert 'inflow' in result.dtype.names
+        assert 'storage' in result.dtype.names
+        assert 'spill' in result.dtype.names
+        # Check dtypes
+        # pylint: disable=unsubscriptable-object
+        assert result.dtype['timestep'] == np.int32
+        assert result.dtype['inflow'] == np.float64
+        assert result.dtype['storage'] == np.float64
+        assert result.dtype['spill'] == np.float64
+
+    def test_simulate_preserves_original_reservoir(self):
+        """Test that original reservoir is unchanged after simulation."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        original_storage = res.storage
+        inflows = [10.0, 20.0, 30.0]
+
+        simulate(res, inflows)
+
+        # Original reservoir should be unchanged
+        assert res.storage == original_storage
+
+    def test_simulate_records_correct_values(self):
+        """Test that simulation records correct storage and spill values."""
+        res = reservoir.factory(name="Test", storage=0.0, capacity=100.0)
+        inflows = [50.0, 60.0, 40.0]
+
+        result = simulate(res, inflows)
+
+        # Check timesteps
+        assert result['timestep'][0] == 0
+        assert result['timestep'][1] == 1
+        assert result['timestep'][2] == 2
+
+        # Check inflows are recorded
+        assert result['inflow'][0] == 50.0
+        assert result['inflow'][1] == 60.0
+        assert result['inflow'][2] == 40.0
+
+        # Check storage progression (no outlets, so no release except spill)
+        # t=0: storage = 0 + 50 - 0 = 50
+        assert result['storage'][0] == 50.0
+        assert result['spill'][0] == 0.0
+
+        # t=1: storage = 50 + 60 - 10 (spill) = 100
+        assert result['storage'][1] == 100.0
+        assert result['spill'][1] == 10.0
+
+        # t=2: storage = 100 + 40 - 40 (spill) = 100
+        assert result['storage'][2] == 100.0
+        assert result['spill'][2] == 40.0
+
+
+class TestSimulateEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    def test_simulate_empty_inflows_returns_empty_array(self):
+        """Test that empty inflows returns empty array with correct dtype."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows: list[float] = []
+
+        result = simulate(res, inflows)
+
+        assert len(result) == 0
+        assert isinstance(result, np.ndarray)
+        # Should still have the right column structure
+        assert 'timestep' in result.dtype.names
+        assert 'inflow' in result.dtype.names
+        assert 'storage' in result.dtype.names
+        assert 'spill' in result.dtype.names
+
+    def test_simulate_accepts_negative_inflows(self):
+        """Test that negative inflows (evaporation) are accepted."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows = [10.0, -5.0, 15.0]
+
+        result = simulate(res, inflows)
+
+        # Check negative inflow is recorded
+        assert result['inflow'][1] == -5.0
+
+        # Check storage calculation with negative inflow
+        # t=0: storage = 50 + 10 = 60
+        # t=1: storage = 60 + (-5) = 55
+        # t=2: storage = 55 + 15 = 70
+        assert result['storage'][0] == 60.0
+        assert result['storage'][1] == 55.0
+        assert result['storage'][2] == 70.0
+
+    def test_simulate_with_numpy_array_inflows(self):
+        """Test that simulate accepts numpy array inflows."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows = np.array([10.0, 20.0, 15.0])
+
+        result = simulate(res, inflows)
+
+        assert len(result) == 3
+        assert result['inflow'][0] == 10.0

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,9 @@ wheels = [
 name = "canteen"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+]
 
 [package.optional-dependencies]
 units = [
@@ -50,7 +53,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "units", marker = "extra == 'units'", git = "https://github.com/JohnRushKucharski/units" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.4.4" },
+    { name = "units", marker = "extra == 'units'", git = "https://github.com/JohnRushKucharski/units" },
+]
 provides-extras = ["units"]
 
 [package.metadata.requires-dev]
@@ -430,6 +436,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the `simulate()` function that runs a reservoir through multiple timesteps given a sequence of inflows. The function copies the reservoir internally (using `copy.deepcopy`) to preserve the original state, calls `operate(inflow)` for each timestep, and records results in a pre-allocated numpy structured array with columns: timestep, inflow, storage, and spill.

## Changes

- Created `src/canteen/simulation.py` with `simulate()` function
- Added numpy as a runtime dependency (required for structured arrays)
- Exported `simulate` from `canteen.__init__`
- Added comprehensive test coverage in `tests/test_simulation.py` (7 tests, 100% coverage)
- Updated package docstring with simulation usage example

## Acceptance criteria

- [x] `simulate()` accepts reservoir and inflows
- [x] Returns numpy structured array with correct columns and dtypes
- [x] Reservoir copy ensures original is unchanged
- [x] Empty inflows returns empty array with correct dtype
- [x] Negative inflows accepted (evaporation is valid)
- [x] Tests: basic simulation, empty inflows, negative inflows

Closes #20

## Remaining issues

None — all acceptance criteria met with no MINOR findings from review loop.

## Quality validation

All validation checks passed:
- ✅ ruff: All checks passed
- ✅ pylint: 10.00/10
- ✅ mypy: No type errors
- ✅ pytest: 214 tests passed (7 new simulation tests)
- ✅ coverage: simulation.py at 100%
- ✅ SOLID principles: All satisfied
- ✅ ADR compliance: Follows ADR-0002 (uses reservoir.operate() interface), ADR-0003 (works through protocol, no None checks needed)