### PR TITLE
fix(#22): add validation and error messages to simulate()

### DIFF
--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -73,6 +73,13 @@ def simulate(
     if len(inflows) == 0:
         return np.array([], dtype=dtype)
 
+    # Validate reservoir has operations defined
+    if reservoir.operations is None:
+        raise ValueError(
+            "Reservoir must have operations defined. "
+            "Use reservoir.factory() with operations or builder pattern."
+        )
+
     # Copy reservoir to preserve original
     res_copy = copy.deepcopy(reservoir)
 
@@ -83,6 +90,20 @@ def simulate(
     for timestep, inflow in enumerate(inflows):
         # Call operate to get outflows
         outflows = res_copy.operate(inflow)
+
+        # Validate storage bounds after operation
+        if res_copy.storage < 0:
+            raise ValueError(
+                f"Storage became negative at timestep {timestep}: "
+                f"storage={res_copy.storage:.2f}. "
+                f"Check inflows and operations configuration."
+            )
+        if res_copy.storage > res_copy.capacity:
+            raise ValueError(
+                f"Storage exceeded capacity at timestep {timestep}: "
+                f"storage={res_copy.storage:.2f}, capacity={res_copy.capacity:.2f}. "
+                f"Check operations spill behavior."
+            )
 
         # Record results
         result[timestep]['timestep'] = timestep

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -262,7 +262,7 @@ class TestSimulateValidation:
         # Large negative inflow will cause storage to go negative
         inflows = [5.0, -20.0]  # After t=1: storage = 15 + (-20) = -5
 
-        with pytest.raises((ValueError, AssertionError), match="storage|negative"):
+        with pytest.raises(ValueError, match="storage|negative"):
             simulate(res, inflows)
 
     def test_simulate_raises_when_storage_exceeds_capacity(self):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -290,7 +290,7 @@ class TestSimulateValidation:
         )
         inflows = [10.0]  # storage = 95 + 10 - 0 = 105 > capacity
 
-        with pytest.raises((ValueError, AssertionError), match="capacity|exceeds"):
+        with pytest.raises(ValueError, match="capacity|exceeds"):
             simulate(res, inflows)
 
     def test_simulate_accepts_optional_timestamps_parameter(self):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -236,3 +236,72 @@ class TestSimulateOutletTracking:
             )
             with pytest.raises(ValueError, match="conflict with reserved simulation columns"):
                 simulate(res, [10.0])
+
+
+class TestSimulateValidation:
+    """Test validation and error handling in simulation."""
+
+    def test_simulate_raises_when_reservoir_has_no_operations(self):
+        """Test that simulate raises ValueError when reservoir.operations is None."""
+        import pytest
+        from canteen.reservoir import BaseReservoir
+
+        # Create reservoir without operations
+        res = BaseReservoir(name="Test", storage=50.0, capacity=100.0)
+        inflows = [10.0, 20.0]
+
+        with pytest.raises(ValueError, match="operations"):
+            simulate(res, inflows)
+
+    def test_simulate_raises_when_storage_goes_negative(self):
+        """Test that simulate raises error when storage becomes negative."""
+        import pytest
+
+        # Create reservoir with starting storage that will go negative
+        res = reservoir.factory(name="Test", storage=10.0, capacity=100.0)
+        # Large negative inflow will cause storage to go negative
+        inflows = [5.0, -20.0]  # After t=1: storage = 15 + (-20) = -5
+
+        with pytest.raises((ValueError, AssertionError), match="storage|negative"):
+            simulate(res, inflows)
+
+    def test_simulate_raises_when_storage_exceeds_capacity(self):
+        """Test that simulate raises error when storage exceeds capacity after operation."""
+        import pytest
+        from canteen.operations import Operations
+        from canteen.reservoir import Reservoir, BaseReservoir
+
+        # Create custom operations that fails to spill properly (buggy strategy)
+        class BuggyOperations(Operations):
+            """Operations that doesn't release or spill anything."""
+
+            def operate(
+                self, reservoir: Reservoir, inflow: float
+            ) -> tuple[float, ...]:
+                """Return zero outflows (buggy - doesn't spill)."""
+                return (0.0,)  # No spill, will cause capacity overflow
+
+        # Create reservoir with buggy operations directly
+        res = BaseReservoir(
+            name="Test",
+            storage=95.0,
+            capacity=100.0,
+            operations=BuggyOperations()
+        )
+        inflows = [10.0]  # storage = 95 + 10 - 0 = 105 > capacity
+
+        with pytest.raises((ValueError, AssertionError), match="capacity|exceeds"):
+            simulate(res, inflows)
+
+    def test_simulate_accepts_optional_timestamps_parameter(self):
+        """Test that simulate accepts optional timestamps parameter."""
+        res = reservoir.factory(name="Test", storage=50.0, capacity=100.0)
+        inflows = [10.0, 20.0, 15.0]
+        timestamps = ['2024-01-01', '2024-01-02', '2024-01-03']
+
+        # Should not raise - timestamps parameter exists
+        result = simulate(res, inflows, timestamps=timestamps)
+
+        # Result should be returned successfully
+        assert result is not None
+        assert len(result) == 3


### PR DESCRIPTION
## Summary

Added validation and clear error messages to `simulate()` to catch configuration issues and operational bugs early. The function now validates that reservoirs have operations defined and checks storage bounds after each timestep.

## Changes

- Added validation at simulation start: raises `ValueError` if `reservoir.operations is None`
- Added per-timestep validation: raises `ValueError` if storage becomes negative or exceeds capacity
- Error messages include timestep number and current values for debugging
- Added 4 comprehensive tests for validation behavior
- Optional `timestamps` parameter already existed (no change needed)

## Acceptance criteria

- [x] Validate `reservoir.operations is not None` at start of simulate()
- [x] After each timestep, assert `0 <= storage <= capacity`
- [x] Optional timestamps parameter (already implemented)
- [x] Clear error messages with timestep and value context

Closes #22

## Remaining issues

None - all validation suite checks pass:
- ✅ Ruff: Clean
- ✅ Mypy: Clean
- ✅ Pylint: 9.99/10
- ✅ Tests: 223 passed, simulation.py 100% coverage
- ✅ SOLID: No violations
- ✅ ADR: All compliant

Minor: Two pylint warnings in test code (acceptable patterns - test double signature simplification and pytest name shadowing)