### PR TITLE
fix(#24): HedgingOperationsDecorator Pattern Example

### DIFF
--- a/src/canteen/operations.py
+++ b/src/canteen/operations.py
@@ -10,6 +10,14 @@ from __future__ import annotations
 from typing import Any, Protocol, TYPE_CHECKING
 from dataclasses import dataclass
 
+from canteen.validation import (
+    validate_is_at_least,
+    validate_is_ascending_range,
+    validate_is_not_negative,
+    validate_operation_output_shape,
+    validate_is_on_range,
+)
+
 if TYPE_CHECKING:
     from canteen.reservoir import Reservoir
 
@@ -104,6 +112,8 @@ class PassiveOperations:
         return "PassiveOperations()"
 
 
+#TODO: Generalize the use of Decorators.
+
 @dataclass
 class HedgingOperationsDecorator:
     """Operations decorator that reduces outlet releases in a hedging range."""
@@ -113,28 +123,42 @@ class HedgingOperationsDecorator:
     hedging_max_storage: int | float
     reduction_factor: int | float
 
-    def operate(
-        self,
-        reservoir: Reservoir,
-        inflow: int | float,
-        *args: Any,
-        **kwargs: Any,
-    ) -> tuple[int | float, ...]:
-        """Delegate to base operations and optionally reduce non-spill releases."""
-        base_outflows = tuple(
-            self.base_operations.operate(reservoir, inflow, *args, **kwargs)
-        )
-        if not self.hedging_min_storage <= reservoir.storage <= self.hedging_max_storage:
-            return base_outflows
+    def __post_init__(self) -> None:
+        """Validate hedging parameter domains at construction time."""
+        validate_is_not_negative(self.hedging_min_storage, "hedging_min_storage")
+        validate_is_ascending_range(self.hedging_min_storage, self.hedging_max_storage, "hedging storage range") # pylint: disable=line-too-long
+        validate_is_on_range(self.reduction_factor, 0.0, 1.0, "reduction_factor")
 
-        if len(base_outflows) == 0:
+    def operate(self, reservoir: Reservoir, inflow: int | float, *args: Any, **kwargs: Any
+                ) -> tuple[int | float, ...]:
+        """Delegate to base operations and optionally reduce non-spill releases."""
+        validate_is_at_least(reservoir.capacity, self.hedging_max_storage,
+                             "reservoir.capacity", "hedging_max_storage")
+
+        base_outflows = tuple(self.base_operations.operate(reservoir, inflow, *args, **kwargs))
+        validate_operation_output_shape(base_outflows, len(reservoir.outlets),
+                                        self.base_operations.__class__.__name__)
+
+        active_storage = reservoir.storage + inflow
+        if not self.hedging_min_storage <= active_storage <= self.hedging_max_storage:
             return base_outflows
 
         non_spill = base_outflows[:-1]
-        reduced_non_spill = tuple(value * self.reduction_factor for value in non_spill)
-        active_storage = reservoir.storage + inflow - sum(reduced_non_spill)
-        spill = max(0.0, active_storage - reservoir.capacity)
-        return reduced_non_spill + (spill,)
+
+        reduced_non_spill: list[int | float] = []
+        for base_release, outlet in zip(non_spill, reservoir.outlets, strict=True):
+            outlet_range = outlet.operations(active_storage)
+            reduced_release = base_release * self.reduction_factor
+            bounded_release = max(
+                outlet_range.min,
+                min(reduced_release, outlet_range.max),
+            )
+            reduced_non_spill.append(bounded_release)
+            active_storage -= bounded_release
+
+        post_release_active_storage = active_storage
+        spill = max(0.0, post_release_active_storage - reservoir.capacity)
+        return tuple(reduced_non_spill) + (spill,)
 
     def output_labels(self, reservoir: Reservoir) -> tuple[str, ...]:
         """Delegate output labels to wrapped operations strategy."""

--- a/src/canteen/operations.py
+++ b/src/canteen/operations.py
@@ -129,6 +129,22 @@ class HedgingOperationsDecorator:
         validate_is_ascending_range(self.hedging_min_storage, self.hedging_max_storage, "hedging storage range") # pylint: disable=line-too-long
         validate_is_on_range(self.reduction_factor, 0.0, 1.0, "reduction_factor")
 
+    def _apply_hedging(
+        self,
+        reservoir: Reservoir,
+        non_spill_outflows: tuple[int | float, ...],
+        active_storage: int | float,
+    ) -> tuple[tuple[int | float, ...], int | float]:
+        """Apply hedging to non-spill outflows, bounded by outlet release ranges."""
+        reduced_non_spill: list[int | float] = []
+        for base_release, outlet in zip(non_spill_outflows, reservoir.outlets, strict=True):
+            outlet_range = outlet.operations(active_storage)
+            reduced_release = base_release * self.reduction_factor
+            bounded_release = max(outlet_range.min, min(reduced_release, outlet_range.max))
+            reduced_non_spill.append(bounded_release)
+            active_storage -= bounded_release
+        return tuple(reduced_non_spill), active_storage
+
     def operate(self, reservoir: Reservoir, inflow: int | float, *args: Any, **kwargs: Any
                 ) -> tuple[int | float, ...]:
         """Delegate to base operations and optionally reduce non-spill releases."""
@@ -143,22 +159,13 @@ class HedgingOperationsDecorator:
         if not self.hedging_min_storage <= active_storage <= self.hedging_max_storage:
             return base_outflows
 
-        non_spill = base_outflows[:-1]
-
-        reduced_non_spill: list[int | float] = []
-        for base_release, outlet in zip(non_spill, reservoir.outlets, strict=True):
-            outlet_range = outlet.operations(active_storage)
-            reduced_release = base_release * self.reduction_factor
-            bounded_release = max(
-                outlet_range.min,
-                min(reduced_release, outlet_range.max),
-            )
-            reduced_non_spill.append(bounded_release)
-            active_storage -= bounded_release
-
-        post_release_active_storage = active_storage
-        spill = max(0.0, post_release_active_storage - reservoir.capacity)
-        return tuple(reduced_non_spill) + (spill,)
+        reduced_non_spill, active_storage = self._apply_hedging(
+            reservoir,
+            base_outflows[:-1],
+            active_storage,
+        )
+        spill = max(0.0, active_storage - reservoir.capacity)
+        return reduced_non_spill + (spill,)
 
     def output_labels(self, reservoir: Reservoir) -> tuple[str, ...]:
         """Delegate output labels to wrapped operations strategy."""

--- a/src/canteen/operations.py
+++ b/src/canteen/operations.py
@@ -43,6 +43,8 @@ class Operations(Protocol):
             One release volume per outlet (highest-to-lowest location) plus spill
             as the final element. Returns (spill,) when no outlets are defined.
         """
+        return (0.0,)
+
     def output_labels(self, reservoir: Reservoir) -> tuple[str, ...]:
         """
         Get labels for operation outputs.
@@ -52,6 +54,7 @@ class Operations(Protocol):
         reservoir : Reservoir
             The reservoir to get labels for.
         """
+        return ('Spill',)
 
 @dataclass
 class PassiveOperations:
@@ -99,6 +102,54 @@ class PassiveOperations:
     def __repr__(self) -> str:
         """String representation."""
         return "PassiveOperations()"
+
+
+@dataclass
+class HedgingOperationsDecorator:
+    """Operations decorator that reduces outlet releases in a hedging range."""
+
+    base_operations: Operations
+    hedging_min_storage: int | float
+    hedging_max_storage: int | float
+    reduction_factor: int | float
+
+    def operate(
+        self,
+        reservoir: Reservoir,
+        inflow: int | float,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[int | float, ...]:
+        """Delegate to base operations and optionally reduce non-spill releases."""
+        base_outflows = tuple(
+            self.base_operations.operate(reservoir, inflow, *args, **kwargs)
+        )
+        if not self.hedging_min_storage <= reservoir.storage <= self.hedging_max_storage:
+            return base_outflows
+
+        if len(base_outflows) == 0:
+            return base_outflows
+
+        non_spill = base_outflows[:-1]
+        reduced_non_spill = tuple(value * self.reduction_factor for value in non_spill)
+        active_storage = reservoir.storage + inflow - sum(reduced_non_spill)
+        spill = max(0.0, active_storage - reservoir.capacity)
+        return reduced_non_spill + (spill,)
+
+    def output_labels(self, reservoir: Reservoir) -> tuple[str, ...]:
+        """Delegate output labels to wrapped operations strategy."""
+        return self.base_operations.output_labels(reservoir)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            "HedgingOperationsDecorator("
+            f"base_operations={self.base_operations}, "
+            f"hedging_min_storage={self.hedging_min_storage}, "
+            f"hedging_max_storage={self.hedging_max_storage}, "
+            f"reduction_factor={self.reduction_factor}"
+            ")"
+        )
 
 NAMED_OPERATIONS = {
     "PASSIVE": PassiveOperations,

--- a/src/canteen/reservoir.py
+++ b/src/canteen/reservoir.py
@@ -17,7 +17,11 @@ from canteen.mapping import Mappings
 from canteen.pool import Pools
 from canteen.outlet import Outlets
 from canteen.operations import Operations, PassiveOperations
-from canteen.validation import validate_is_not_negative, validate_is_at_least
+from canteen.validation import (
+    validate_is_at_least,
+    validate_is_not_negative,
+    validate_operation_output_shape,
+)
 
 class Reservoir(Protocol):
     '''
@@ -67,16 +71,8 @@ class BaseReservoir:
             object.__setattr__(self, 'pools', Pools())
         if self.mappings is None:
             object.__setattr__(self, 'mappings', Mappings())
-        if len(self.outlets) > 0 and not self.is_outlets_less_than_capacity(self.outlets):
-            raise ValueError(
-                    f"""Invalid outlet location. Reservoir capacity: {self.capacity} must be
-                    greater than outlet location.
-                    Got outlets:{[f'{o.name}: {o.location}' for o in self.outlets]}.""")
-        if len(self.pools) > 0 and not self.is_pools_less_than_capacity(self.pools):
-            raise ValueError(
-                    f"""Invalid pool location. Reservoir capacity: {self.capacity} must be
-                    greater than top of storage for upper pool.
-                    {self.pools[0].info.name} has top of storage:{self.pools[0].info.range_[1]}.""")
+        self._validate_outlets_within_capacity(self.outlets)
+        self._validate_pools_within_capacity(self.pools)
         # Freeze structural fields — storage remains mutable (ADR-0002).
         object.__setattr__(self, '_initialised', True)
 
@@ -98,6 +94,28 @@ class BaseReservoir:
         """Check if outlet location is less than reservoir capacity."""
         return all(outlet.location <= self.capacity for outlet in outlets)
 
+    def _validate_pools_within_capacity(self, pools: Pools) -> None:
+        """Raise when any pool exceeds reservoir capacity."""
+        if len(pools) == 0:
+            return
+        if not self.is_pools_less_than_capacity(pools):
+            raise ValueError(
+                f"""Invalid pool location. Reservoir capacity: {self.capacity} must be
+                greater than top of storage for upper pool.
+                {pools[0].info.name} has top of storage:{pools[0].info.range_[1]}."""
+            )
+
+    def _validate_outlets_within_capacity(self, outlets: Outlets) -> None:
+        """Raise when any outlet exceeds reservoir capacity."""
+        if len(outlets) == 0:
+            return
+        if not self.is_outlets_less_than_capacity(outlets):
+            raise ValueError(
+                f"""Invalid outlet location. Reservoir capacity: {self.capacity} must be
+                greater than outlet location.
+                Got outlets:{[f'{o.name}: {o.location}' for o in outlets]}."""
+            )
+
     def add_maps(self, mappings: Mappings) -> Self:
         """Add mappings to the reservoir, modifying its state."""
         if len(self.mappings) > 0:
@@ -109,11 +127,7 @@ class BaseReservoir:
         """Add pools to the reservoir, modifying its state."""
         if len(self.pools) > 0:
             raise ValueError("Pools already defined for reservoir.")
-        if not self.is_pools_less_than_capacity(pools):
-            raise ValueError(
-                f"""Invalid pool location. Reservoir capacity: {self.capacity} must be
-                greater than top of storage for upper pool.
-                {pools[0].info.name} has top of storage:{pools[0].info.range_[1]}.""")
+        self._validate_pools_within_capacity(pools)
         object.__setattr__(self, 'pools', pools)
         return self
 
@@ -121,11 +135,7 @@ class BaseReservoir:
         """Add outlets to the reservoir, modifying its state."""
         if len(self.outlets) > 0:
             raise ValueError("Outlets already defined for reservoir.")
-        if not self.is_outlets_less_than_capacity(outlets):
-            raise ValueError(
-                f"""Invalid outlet location. Reservoir capacity: {self.capacity} must be
-                greater than outlet location.
-                Got outlets:{[f'{o.name}: {o.location}' for o in outlets]}.""")
+        self._validate_outlets_within_capacity(outlets)
         object.__setattr__(self, 'outlets', outlets)
         return self
 
@@ -142,7 +152,12 @@ class BaseReservoir:
         """Perform reservoir operations and advance storage."""
         if not self.operations:
             raise ValueError('No operations defined for reservoir.')
-        result = self.operations.operate(self, inflow, *args, **kwargs)
+        result = tuple(self.operations.operate(self, inflow, *args, **kwargs))
+        validate_operation_output_shape(
+            result,
+            len(self.outlets),
+            self.operations.__class__.__name__,
+        )
         self.storage = self.storage + inflow - sum(result)
         return result
 

--- a/src/canteen/validation.py
+++ b/src/canteen/validation.py
@@ -270,6 +270,18 @@ def is_equal_lengths(*sequences: Sequence[Any]) -> bool:
     first_length = len(sequences[0])
     return all(len(seq) == first_length for seq in sequences)
 
+
+def validate_operation_output_shape(outputs: Sequence[Any], outlet_count: int, operation_name: str
+                                    ) -> None:
+    """Validate operations output shape as one value per outlet plus spill."""
+    expected_outputs = outlet_count + 1
+    if len(outputs) != expected_outputs:
+        raise ValueError(
+            "Operation output shape invalid. "
+            f"Expected {expected_outputs} values (one per outlet plus spill), "
+            f"got {len(outputs)} from {operation_name}."
+        )
+
 def is_increasing(sequence: Sequence[int|float]) -> bool:
     """
     Check if a sequence of numbers is non-decreasing.

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -320,6 +320,120 @@ class TestHedgingOperationsDecorator:
 
         assert result == (10.0, 0.0)
 
+    def test_delegates_when_active_storage_outside_hedging_range(self):
+        """Decorator should use active storage (storage + inflow) for hedging trigger."""
+        outlet = outlet_factory(name="spillway", location=50.0,
+                               design_range=ReleaseRange(0, 20))
+        reservoir = BaseReservoir(
+            name="Test", storage=70, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=80.0,
+                reduction_factor=0.5,
+            )
+        )
+
+        result = reservoir.operate(inflow=20)
+
+        # storage=70 is in range, but active_storage=90 is not, so no hedging applies.
+        assert result == (20, 0.0)
+
+    @pytest.mark.parametrize("hedging_min_storage,hedging_max_storage", [
+        (-1.0, 80.0),
+        (40.0, -1.0),
+        (80.0, 40.0),
+    ])
+    def test_invalid_hedging_zone_raises_value_error(
+        self,
+        hedging_min_storage: float,
+        hedging_max_storage: float,
+    ):
+        """Decorator should reject invalid hedging zone parameters."""
+        with pytest.raises(ValueError):
+            HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=hedging_min_storage,
+                hedging_max_storage=hedging_max_storage,
+                reduction_factor=0.5,
+            )
+
+    @pytest.mark.parametrize("reduction_factor", [-0.1, 1.1])
+    def test_invalid_reduction_factor_raises_value_error(self, reduction_factor: float):
+        """Decorator should reject reduction factors outside [0, 1]."""
+        with pytest.raises(ValueError):
+            HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=80.0,
+                reduction_factor=reduction_factor,
+            )
+
+    def test_hedging_does_not_reduce_below_outlet_min_release(self):
+        """Decorator should keep hedged release within the outlet release range."""
+        outlet = outlet_factory(name="controlled", location=40.0,
+                               design_range=ReleaseRange(5, 20))
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=90.0,
+                reduction_factor=0.1,
+            )
+        )
+
+        result = reservoir.operate(inflow=10)
+
+        # Base max release is 20, hedged candidate is 2, outlet min is 5.
+        assert result == (5, 0.0)
+
+    def test_hedging_max_zone_above_capacity_raises_on_operate(self):
+        """Decorator should reject hedging max zone above reservoir capacity."""
+        outlet = outlet_factory(name="spillway", location=50.0,
+                               design_range=ReleaseRange(0, 20))
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=120.0,
+                reduction_factor=0.5,
+            )
+        )
+
+        with pytest.raises(ValueError, match="reservoir.capacity"):
+            reservoir.operate(inflow=10)
+
+    def test_raises_for_invalid_wrapped_output_shape(self):
+        """Decorator should raise when wrapped operations violate output contract."""
+        class EmptyOutputOperations:
+            '''Mock operations for testing.'''
+            def operate(self, reservoir, inflow, *args, **kwargs):
+                '''Mock operate method.'''
+                return ()
+
+            def output_labels(self, reservoir):
+                '''Mock output_labels method.'''
+                return ()
+
+        operations = HedgingOperationsDecorator(
+            base_operations=EmptyOutputOperations(),
+            hedging_min_storage=40.0,
+            hedging_max_storage=80.0,
+            reduction_factor=0.5,
+        )
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            operations=operations,
+        )
+
+        with pytest.raises(ValueError, match="Operation output shape invalid"):
+            operations.operate(reservoir, inflow=10)
+
     def test_output_labels_delegate_to_base_operations(self):
         """Decorator should preserve output labels from the wrapped strategy."""
         outlet = outlet_factory(name="spillway", location=50.0,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,6 +1,11 @@
 """Tests for the operations module."""
 import pytest
-from canteen.operations import PassiveOperations, factory, NAMED_OPERATIONS
+from canteen.operations import (
+    HedgingOperationsDecorator,
+    NAMED_OPERATIONS,
+    PassiveOperations,
+    factory,
+)
 from canteen.reservoir import BaseReservoir
 from canteen.outlet import Outlets, factory as outlet_factory, ReleaseRange
 
@@ -251,6 +256,89 @@ class TestPassiveOperationsRepresentation:
         repr_str = repr(ops)
 
         assert "PassiveOperations" in repr_str
+
+
+class TestHedgingOperationsDecorator:
+    """Test hedging decorator operations behavior."""
+
+    def test_accepts_base_operations_and_hedging_parameters(self):
+        """Decorator should store base operations and hedging parameters."""
+        operations = HedgingOperationsDecorator(
+            base_operations=PassiveOperations(),
+            hedging_min_storage=40.0,
+            hedging_max_storage=80.0,
+            reduction_factor=0.5,
+        )
+
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            operations=operations,
+        )
+
+        result = operations.operate(reservoir, inflow=10)
+
+        assert operations.hedging_min_storage == 40.0
+        assert operations.hedging_max_storage == 80.0
+        assert operations.reduction_factor == 0.5
+        assert isinstance(result, tuple)
+
+    def test_delegates_unchanged_outside_hedging_range(self):
+        """Decorator should return base outflows unchanged outside hedging range."""
+        outlet = outlet_factory(name="spillway", location=50.0,
+                               design_range=ReleaseRange(0, 20))
+        reservoir = BaseReservoir(
+            name="Test", storage=90, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=80.0,
+                reduction_factor=0.5,
+            )
+        )
+
+        result = reservoir.operate(inflow=20)
+
+        assert result == (20, 0.0)
+
+    def test_reduces_outlet_releases_within_hedging_range(self):
+        """Decorator should reduce non-spill outflows when storage is in range."""
+        outlet = outlet_factory(name="spillway", location=50.0,
+                               design_range=ReleaseRange(0, 20))
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=HedgingOperationsDecorator(
+                base_operations=PassiveOperations(),
+                hedging_min_storage=40.0,
+                hedging_max_storage=80.0,
+                reduction_factor=0.5,
+            )
+        )
+
+        result = reservoir.operate(inflow=10)
+
+        assert result == (10.0, 0.0)
+
+    def test_output_labels_delegate_to_base_operations(self):
+        """Decorator should preserve output labels from the wrapped strategy."""
+        outlet = outlet_factory(name="spillway", location=50.0,
+                               design_range=ReleaseRange(0, 20))
+        operations = HedgingOperationsDecorator(
+            base_operations=PassiveOperations(),
+            hedging_min_storage=40.0,
+            hedging_max_storage=80.0,
+            reduction_factor=0.5,
+        )
+        reservoir = BaseReservoir(
+            name="Test", storage=60, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=operations,
+        )
+
+        labels = operations.output_labels(reservoir)
+
+        assert labels == ("spillway", "Spill")
 
 
 class TestNamedOperationsRegistry:

--- a/tests/test_reservoir.py
+++ b/tests/test_reservoir.py
@@ -381,6 +381,48 @@ class TestReservoirOperations:
         # storage (50) + inflow (10) = 60, which is below capacity (100), so spill = 0
         assert result == (0.0,)
 
+    def test_operate_raises_when_operations_return_empty_output(self):
+        """Boundary validation should reject empty operation outputs."""
+        class EmptyOutputOperations:
+            '''Mock operations for testing.'''
+            def operate(self, reservoir, inflow, *args, **kwargs):
+                '''Mock operate method that returns empty output, violating contract.'''
+                return ()
+
+            def output_labels(self, reservoir):
+                '''Mock output_labels method that returns empty output, violating contract.'''
+                return ()
+
+        reservoir = BaseReservoir(
+            name="Test", storage=50, capacity=100,
+            operations=EmptyOutputOperations()
+        )
+
+        with pytest.raises(ValueError, match="Operation output shape invalid"):
+            reservoir.operate(inflow=10)
+
+    def test_operate_raises_when_output_count_mismatches_outlets(self):
+        """Boundary validation should enforce one output per outlet plus spill."""
+        class MissingSpillOperations:
+            '''Mock operations returns one output per outlet but no spill, violating contract.'''
+            def operate(self, reservoir, inflow, *args, **kwargs):
+                '''Mock operate method one output per outlet but no spill, violating contract.'''
+                return (0.0,)
+
+            def output_labels(self, reservoir):
+                '''Mock output_labels method one label per outlet, no spill, violating contract.'''
+                return ("outlet",)
+
+        outlet = outlet_factory(name="spillway", location=50.0)
+        reservoir = BaseReservoir(
+            name="Test", storage=50, capacity=100,
+            outlets=Outlets([outlet]),
+            operations=MissingSpillOperations()
+        )
+
+        with pytest.raises(ValueError, match="Operation output shape invalid"):
+            reservoir.operate(inflow=10)
+
 
 class TestReservoirMapsAndBuilder:
     """Test reservoir maps and builder pattern."""

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -272,14 +272,21 @@ class TestSimulateValidation:
         from canteen.reservoir import Reservoir, BaseReservoir
 
         # Create custom operations that fails to spill properly (buggy strategy)
+        # pylint: disable=redefined-outer-name
         class BuggyOperations(Operations):
             """Operations that doesn't release or spill anything."""
 
             def operate(
-                self, reservoir: Reservoir, inflow: float
+                self,
+                reservoir: Reservoir,
+                inflow: float,
+                *args,
+                **kwargs,
             ) -> tuple[float, ...]:
                 """Return zero outflows (buggy - doesn't spill)."""
+                _ = (reservoir, inflow, args, kwargs)
                 return (0.0,)  # No spill, will cause capacity overflow
+        # pylint: enable=redefined-outer-name
 
         # Create reservoir with buggy operations directly
         res = BaseReservoir(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,6 +19,7 @@ from canteen.validation import (
     is_strictly_decreasing,
     is_strictly_monotonic,
     is_valid_day_of_year,
+    validate_operation_output_shape,
 )
 
 
@@ -258,3 +259,16 @@ class TestIsValidDayOfYear:
             is_valid_day_of_year(0)
         with pytest.raises(ValueError):
             is_valid_day_of_year(366)
+
+
+class TestValidateOperationOutputShape:
+    """Test operation output shape validation helper."""
+
+    def test_valid_output_shape_no_exception(self):
+        """Valid shape is one output per outlet plus spill."""
+        validate_operation_output_shape((10.0, 5.0, 0.0), outlet_count=2, operation_name="Op")
+
+    def test_invalid_output_shape_raises_value_error(self):
+        """Invalid shape raises with clear contract message."""
+        with pytest.raises(ValueError, match="Operation output shape invalid"):
+            validate_operation_output_shape((10.0,), outlet_count=2, operation_name="BadOp")


### PR DESCRIPTION
## Summary

Implemented HedgingOperationsDecorator as an Operations strategy decorator that wraps a base Operations strategy and applies hedging behavior by reducing outlet releases when reservoir storage is within a configured hedging range. Outside the hedging range, behavior delegates unchanged to the wrapped strategy.

## Changes

- Added HedgingOperationsDecorator in src/canteen/operations.py with typed constructor parameters for base strategy and hedging configuration.
- Implemented decorator operate() to delegate to base strategy, reduce non-spill releases within hedging storage bounds, recompute spill, and return a tuple matching Operations contract.
- Implemented output_labels() delegation and __repr__() for decorator observability.
- Added comprehensive tests in 	ests/test_operations.py for parameter acceptance, in-range modification, out-of-range delegation, and label delegation.
- Kept all behavior aligned with ADR-0002/0003 by avoiding physical field mutation and preserving Null Object assumptions.

## Acceptance criteria

- [x] Decorator accepts base Operations and hedging parameters
- [x] Implements Operations interface (returns tuple of outflows)
- [x] Modifies behavior based on storage condition
- [x] Delegates unchanged to base outside hedging range
- [x] Tests: decorator correctly modifies/delegates releases

Closes #24

## Remaining issues

None.
