### PR TITLE
fix(#23): DataFrame Converters (to_pandas, to_polars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ source .venv/bin/activate  # On Linux/macOS
 .venv\Scripts\activate  # On Windows
 ```
 
+Install optional DataFrame dependencies only if you need converter helpers:
+
+```bash
+# pandas only
+uv sync --extra pandas
+
+# polars only
+uv sync --extra polars
+```
+
 ## Quick Start
 
 ### Building Reservoirs with Components

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,12 @@ dependencies = [
 units = [
     "units",
 ]
+pandas = [
+    "pandas>=2.2.0",
+]
+polars = [
+    "polars>=1.0.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -17,11 +17,8 @@ from canteen.reservoir import Reservoir
 _RESERVED_COLUMNS: frozenset[str] = frozenset({'timestep', 'inflow', 'storage', 'spill'})
 
 
-def simulate(
-    reservoir: Reservoir,
-    inflows: Sequence[float] | NDArray[np.floating[Any]],
-    timestamps: Sequence[Any] | None = None
-) -> NDArray[np.void]:
+def simulate(reservoir: Reservoir, inflows: Sequence[float] | NDArray[np.floating[Any]],
+             timestamps: Sequence[Any] | None = None) -> NDArray[np.void]:
     """
     Simulate reservoir operations over multiple timesteps.
 
@@ -121,15 +118,6 @@ def simulate(
     return result
 
 
-def _to_rows(result: NDArray[np.void]) -> list[dict[str, Any]]:
-    """Convert a numpy structured array into a list of row dicts."""
-    names = result.dtype.names
-    if names is None:
-        raise ValueError("Result must be a numpy structured array with named columns.")
-
-    return [{name: row[name] for name in names} for row in result]
-
-
 def _to_columns(result: NDArray[np.void]) -> dict[str, NDArray[Any]]:
     """Convert a numpy structured array into column arrays keyed by field name."""
     names = result.dtype.names
@@ -148,14 +136,7 @@ def to_pandas(result: NDArray[np.void]) -> Any:
             "pandas is required for to_pandas(). Install it with `uv add pandas`."
         ) from exc
 
-    data_frame = getattr(pd, "DataFrame", None)
-    if data_frame is not None and hasattr(data_frame, "from_records"):
-        return data_frame.from_records(result)
-
-    if len(result) == 0:
-        return pd.DataFrame(_to_columns(result))
-
-    return pd.DataFrame(_to_rows(result))
+    return pd.DataFrame(result)
 
 
 def to_polars(result: NDArray[np.void]) -> Any:

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -8,6 +8,7 @@ calls operate(inflow) for each timestep, and records storage and outflow states.
 
 from typing import Sequence, Any
 import copy
+import importlib
 import numpy as np
 from numpy.typing import NDArray
 
@@ -118,3 +119,36 @@ def simulate(
         result[timestep]['spill'] = outflows[-1]
 
     return result
+
+
+def _to_rows(result: NDArray[np.void]) -> list[dict[str, Any]]:
+    """Convert a numpy structured array into a list of row dicts."""
+    names = result.dtype.names
+    if names is None:
+        raise ValueError("Result must be a numpy structured array with named columns.")
+
+    return [{name: row[name] for name in names} for row in result]
+
+
+def to_pandas(result: NDArray[np.void]) -> Any:
+    """Convert simulation structured-array output to a pandas DataFrame."""
+    try:
+        pd = importlib.import_module("pandas")
+    except ImportError as exc:
+        raise ImportError(
+            "pandas is required for to_pandas(). Install it with `uv add pandas`."
+        ) from exc
+
+    return pd.DataFrame(_to_rows(result))
+
+
+def to_polars(result: NDArray[np.void]) -> Any:
+    """Convert simulation structured-array output to a polars DataFrame."""
+    try:
+        pl = importlib.import_module("polars")
+    except ImportError as exc:
+        raise ImportError(
+            "polars is required for to_polars(). Install it with `uv add polars`."
+        ) from exc
+
+    return pl.DataFrame(_to_rows(result))

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -152,6 +152,9 @@ def to_pandas(result: NDArray[np.void]) -> Any:
     if data_frame is not None and hasattr(data_frame, "from_records"):
         return data_frame.from_records(result)
 
+    if len(result) == 0:
+        return pd.DataFrame(_to_columns(result))
+
     return pd.DataFrame(_to_rows(result))
 
 

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -130,6 +130,15 @@ def _to_rows(result: NDArray[np.void]) -> list[dict[str, Any]]:
     return [{name: row[name] for name in names} for row in result]
 
 
+def _to_columns(result: NDArray[np.void]) -> dict[str, NDArray[Any]]:
+    """Convert a numpy structured array into column arrays keyed by field name."""
+    names = result.dtype.names
+    if names is None:
+        raise ValueError("Result must be a numpy structured array with named columns.")
+
+    return {name: result[name] for name in names}
+
+
 def to_pandas(result: NDArray[np.void]) -> Any:
     """Convert simulation structured-array output to a pandas DataFrame."""
     try:
@@ -138,6 +147,10 @@ def to_pandas(result: NDArray[np.void]) -> Any:
         raise ImportError(
             "pandas is required for to_pandas(). Install it with `uv add pandas`."
         ) from exc
+
+    data_frame = getattr(pd, "DataFrame", None)
+    if data_frame is not None and hasattr(data_frame, "from_records"):
+        return data_frame.from_records(result)
 
     return pd.DataFrame(_to_rows(result))
 
@@ -151,4 +164,13 @@ def to_polars(result: NDArray[np.void]) -> Any:
             "polars is required for to_polars(). Install it with `uv add polars`."
         ) from exc
 
-    return pl.DataFrame(_to_rows(result))
+    columns = _to_columns(result)
+
+    if hasattr(pl, "from_dict"):
+        return pl.from_dict(columns)
+
+    data_frame = getattr(pl, "DataFrame", None)
+    if data_frame is not None:
+        return data_frame(columns)
+
+    raise ValueError("polars module does not expose from_dict() or DataFrame().")

--- a/src/canteen/simulation.py
+++ b/src/canteen/simulation.py
@@ -118,15 +118,6 @@ def simulate(reservoir: Reservoir, inflows: Sequence[float] | NDArray[np.floatin
     return result
 
 
-def _to_columns(result: NDArray[np.void]) -> dict[str, NDArray[Any]]:
-    """Convert a numpy structured array into column arrays keyed by field name."""
-    names = result.dtype.names
-    if names is None:
-        raise ValueError("Result must be a numpy structured array with named columns.")
-
-    return {name: result[name] for name in names}
-
-
 def to_pandas(result: NDArray[np.void]) -> Any:
     """Convert simulation structured-array output to a pandas DataFrame."""
     try:
@@ -148,13 +139,4 @@ def to_polars(result: NDArray[np.void]) -> Any:
             "polars is required for to_polars(). Install it with `uv add polars`."
         ) from exc
 
-    columns = _to_columns(result)
-
-    if hasattr(pl, "from_dict"):
-        return pl.from_dict(columns)
-
-    data_frame = getattr(pl, "DataFrame", None)
-    if data_frame is not None:
-        return data_frame(columns)
-
-    raise ValueError("polars module does not expose from_dict() or DataFrame().")
+    return pl.DataFrame(result)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -398,8 +398,8 @@ class TestSimulationDataFrameConverters:
         assert self._get_value(converted, 0, 'inflow') == 10.0
         assert self._get_value(converted, 1, 'spill') == 5.0
 
-    def test_to_pandas_prefers_from_records_when_available(self):
-        """Test that to_pandas uses DataFrame.from_records when available."""
+    def test_to_pandas_passes_structured_array_directly_to_dataframe(self):
+        """Test that to_pandas passes the structured array directly to DataFrame()."""
         from canteen.simulation import to_pandas
         import sys
         import types
@@ -414,16 +414,12 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        class _FakeDataFrame:
-            """Fake DataFrame class exposing from_records constructor."""
-
-            @staticmethod
-            def from_records(records):
-                """Return records payload for assertion-friendly behavior."""
-                return {'records': records}
+        def _dataframe(data):
+            """Capture the argument passed to DataFrame() for assertion."""
+            return {'data': data}
 
         monkey_module = types.ModuleType("pandas")
-        monkey_module.DataFrame = _FakeDataFrame
+        monkey_module.DataFrame = _dataframe
         old_pandas = sys.modules.get("pandas")
         sys.modules["pandas"] = monkey_module
         try:
@@ -434,8 +430,9 @@ class TestSimulationDataFrameConverters:
             else:
                 sys.modules["pandas"] = old_pandas
 
-        assert isinstance(converted, dict)
-        assert converted['records'][0]['timestep'] == 0
+        # Fake receives the raw structured array — not a row-dict list
+        assert isinstance(converted['data'], np.ndarray)
+        assert converted['data'].dtype.names == ('timestep', 'inflow', 'storage', 'spill')
 
     def test_converters_handle_results_with_outlet_columns_and_timestamps(self):
         """Test converter compatibility with richer simulation schemas."""
@@ -511,9 +508,9 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        def _pandas_dataframe(columns):
-            """Return columns payload for assertion-friendly fake dataframe behavior."""
-            return {'columns': columns}
+        def _pandas_dataframe(data):
+            """Return data payload for assertion-friendly fake dataframe behavior."""
+            return {'data': data}
 
         def _polars_dataframe(columns):
             """Return columns payload for assertion-friendly fake dataframe behavior."""
@@ -549,7 +546,7 @@ class TestSimulationDataFrameConverters:
             'MainGate',
             'spill',
         ]
-        assert list(pandas_df['columns'].keys()) == expected_columns
+        assert list(pandas_df['data'].dtype.names) == expected_columns
         assert list(polars_df['columns'].keys()) == expected_columns
 
     def test_to_pandas_raises_helpful_error_when_pandas_missing(self, monkeypatch):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -493,10 +493,11 @@ class TestSimulationDataFrameConverters:
         assert self._get_value(polars_df, 0, 'MainGate') == 2.0
         assert self._get_value(polars_df, 1, 'spill') == 1.0
 
-    def test_to_pandas_raises_helpful_error_when_pandas_missing(self):
+    def test_to_pandas_raises_helpful_error_when_pandas_missing(self, monkeypatch):
         """Test that to_pandas raises ImportError with helpful guidance."""
-        import builtins
         import pytest
+        import sys
+        from importlib import import_module as real_import_module
 
         from canteen.simulation import to_pandas
 
@@ -510,24 +511,22 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        real_import = builtins.__import__
-
-        def _fake_import(name, *args, **kwargs):
+        def _fake_import(name, package=None):
             if name == "pandas":
                 raise ImportError("No module named pandas")
-            return real_import(name, *args, **kwargs)
+            return real_import_module(name, package)
 
-        builtins.__import__ = _fake_import
-        try:
-            with pytest.raises(ImportError, match="pandas"):
-                to_pandas(result)
-        finally:
-            builtins.__import__ = real_import
+        monkeypatch.setattr("canteen.simulation.importlib.import_module", _fake_import)
+        monkeypatch.delitem(sys.modules, "pandas", raising=False)
 
-    def test_to_polars_raises_helpful_error_when_polars_missing(self):
+        with pytest.raises(ImportError, match="pandas"):
+            to_pandas(result)
+
+    def test_to_polars_raises_helpful_error_when_polars_missing(self, monkeypatch):
         """Test that to_polars raises ImportError with helpful guidance."""
-        import builtins
         import pytest
+        import sys
+        from importlib import import_module as real_import_module
 
         from canteen.simulation import to_polars
 
@@ -541,16 +540,13 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        real_import = builtins.__import__
-
-        def _fake_import(name, *args, **kwargs):
+        def _fake_import(name, package=None):
             if name == "polars":
                 raise ImportError("No module named polars")
-            return real_import(name, *args, **kwargs)
+            return real_import_module(name, package)
 
-        builtins.__import__ = _fake_import
-        try:
-            with pytest.raises(ImportError, match="polars"):
-                to_polars(result)
-        finally:
-            builtins.__import__ = real_import
+        monkeypatch.setattr("canteen.simulation.importlib.import_module", _fake_import)
+        monkeypatch.delitem(sys.modules, "polars", raising=False)
+
+        with pytest.raises(ImportError, match="polars"):
+            to_polars(result)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -317,6 +317,13 @@ class TestSimulateValidation:
 class TestSimulationDataFrameConverters:
     """Test structured-array to DataFrame converter helpers."""
 
+    @staticmethod
+    def _get_value(frame_payload, row_index, column_name):
+        """Read values from fake row- or column-oriented frame payloads."""
+        if 'rows' in frame_payload:
+            return frame_payload['rows'][row_index][column_name]
+        return frame_payload['columns'][column_name][row_index]
+
     def test_to_pandas_converts_structured_array_to_dataframe(self):
         """Test that to_pandas converts simulation result to pandas DataFrame."""
         from canteen.simulation import to_pandas
@@ -370,9 +377,9 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        def _dataframe(rows):
-            """Return rows payload for assertion-friendly fake dataframe behavior."""
-            return {'rows': rows}
+        def _dataframe(columns):
+            """Return columns payload for assertion-friendly fake dataframe behavior."""
+            return {'columns': columns}
 
         monkey_module = types.ModuleType("polars")
         monkey_module.DataFrame = _dataframe
@@ -387,9 +394,48 @@ class TestSimulationDataFrameConverters:
                 sys.modules["polars"] = old_polars
 
         assert isinstance(converted, dict)
-        assert len(converted['rows']) == 2
-        assert converted['rows'][0]['inflow'] == 10.0
-        assert converted['rows'][1]['spill'] == 5.0
+        assert len(converted['columns']['timestep']) == 2
+        assert self._get_value(converted, 0, 'inflow') == 10.0
+        assert self._get_value(converted, 1, 'spill') == 5.0
+
+    def test_to_pandas_prefers_from_records_when_available(self):
+        """Test that to_pandas uses DataFrame.from_records when available."""
+        from canteen.simulation import to_pandas
+        import sys
+        import types
+
+        result = np.array(
+            [(0, 10.0, 50.0, 0.0)],
+            dtype=[
+                ('timestep', np.int32),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        class _FakeDataFrame:
+            """Fake DataFrame class exposing from_records constructor."""
+
+            @staticmethod
+            def from_records(records):
+                """Return records payload for assertion-friendly behavior."""
+                return {'records': records}
+
+        monkey_module = types.ModuleType("pandas")
+        monkey_module.DataFrame = _FakeDataFrame
+        old_pandas = sys.modules.get("pandas")
+        sys.modules["pandas"] = monkey_module
+        try:
+            converted = to_pandas(result)
+        finally:
+            if old_pandas is None:
+                del sys.modules["pandas"]
+            else:
+                sys.modules["pandas"] = old_pandas
+
+        assert isinstance(converted, dict)
+        assert converted['records'][0]['timestep'] == 0
 
     def test_converters_handle_results_with_outlet_columns_and_timestamps(self):
         """Test converter compatibility with richer simulation schemas."""
@@ -412,16 +458,20 @@ class TestSimulationDataFrameConverters:
             ],
         )
 
-        def _dataframe(rows):
+        def _pandas_dataframe(rows):
             """Return rows payload for assertion-friendly fake dataframe behavior."""
             return {'rows': rows}
+
+        def _polars_dataframe(columns):
+            """Return columns payload for assertion-friendly fake dataframe behavior."""
+            return {'columns': columns}
 
         old_pandas = sys.modules.get("pandas")
         old_polars = sys.modules.get("polars")
         fake_pd = types.ModuleType("pandas")
-        fake_pd.DataFrame = _dataframe
+        fake_pd.DataFrame = _pandas_dataframe
         fake_pl = types.ModuleType("polars")
-        fake_pl.DataFrame = _dataframe
+        fake_pl.DataFrame = _polars_dataframe
 
         sys.modules["pandas"] = fake_pd
         sys.modules["polars"] = fake_pl
@@ -438,10 +488,10 @@ class TestSimulationDataFrameConverters:
             else:
                 sys.modules["polars"] = old_polars
 
-        assert pandas_df['rows'][0]['timestamp'] == np.datetime64('2026-01-01')
-        assert pandas_df['rows'][1]['MainGate'] == 3.0
-        assert polars_df['rows'][0]['MainGate'] == 2.0
-        assert polars_df['rows'][1]['spill'] == 1.0
+        assert self._get_value(pandas_df, 0, 'timestamp') == np.datetime64('2026-01-01')
+        assert self._get_value(pandas_df, 1, 'MainGate') == 3.0
+        assert self._get_value(polars_df, 0, 'MainGate') == 2.0
+        assert self._get_value(polars_df, 1, 'spill') == 1.0
 
     def test_to_pandas_raises_helpful_error_when_pandas_missing(self):
         """Test that to_pandas raises ImportError with helpful guidance."""

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -322,7 +322,7 @@ class TestSimulationDataFrameConverters:
         """Read values from fake row- or column-oriented frame payloads."""
         if 'rows' in frame_payload:
             return frame_payload['rows'][row_index][column_name]
-        return frame_payload['columns'][column_name][row_index]
+        return frame_payload['data'][row_index][column_name]
 
     def test_to_pandas_converts_structured_array_to_dataframe(self):
         """Test that to_pandas converts simulation result to pandas DataFrame."""
@@ -378,8 +378,8 @@ class TestSimulationDataFrameConverters:
         )
 
         def _dataframe(columns):
-            """Return columns payload for assertion-friendly fake dataframe behavior."""
-            return {'columns': columns}
+            """Return data payload for assertion-friendly fake dataframe behavior."""
+            return {'data': columns}
 
         monkey_module = types.ModuleType("polars")
         monkey_module.DataFrame = _dataframe
@@ -394,7 +394,7 @@ class TestSimulationDataFrameConverters:
                 sys.modules["polars"] = old_polars
 
         assert isinstance(converted, dict)
-        assert len(converted['columns']['timestep']) == 2
+        assert len(converted['data']) == 2
         assert self._get_value(converted, 0, 'inflow') == 10.0
         assert self._get_value(converted, 1, 'spill') == 5.0
 
@@ -460,8 +460,8 @@ class TestSimulationDataFrameConverters:
             return {'rows': rows}
 
         def _polars_dataframe(columns):
-            """Return columns payload for assertion-friendly fake dataframe behavior."""
-            return {'columns': columns}
+            """Return data payload for assertion-friendly fake dataframe behavior."""
+            return {'data': columns}
 
         old_pandas = sys.modules.get("pandas")
         old_polars = sys.modules.get("polars")
@@ -487,8 +487,8 @@ class TestSimulationDataFrameConverters:
 
         assert self._get_value(pandas_df, 0, 'timestamp') == np.datetime64('2026-01-01')
         assert self._get_value(pandas_df, 1, 'MainGate') == 3.0
-        assert self._get_value(polars_df, 0, 'MainGate') == 2.0
-        assert self._get_value(polars_df, 1, 'spill') == 1.0
+        assert polars_df['data'][0]['MainGate'] == 2.0
+        assert polars_df['data'][1]['spill'] == 1.0
 
     def test_converters_preserve_schema_for_empty_results(self):
         """Test empty structured arrays preserve dtype schema columns in converters."""
@@ -513,8 +513,8 @@ class TestSimulationDataFrameConverters:
             return {'data': data}
 
         def _polars_dataframe(columns):
-            """Return columns payload for assertion-friendly fake dataframe behavior."""
-            return {'columns': columns}
+            """Return data payload for assertion-friendly fake dataframe behavior."""
+            return {'data': columns}
 
         old_pandas = sys.modules.get("pandas")
         old_polars = sys.modules.get("polars")
@@ -547,7 +547,7 @@ class TestSimulationDataFrameConverters:
             'spill',
         ]
         assert list(pandas_df['data'].dtype.names) == expected_columns
-        assert list(polars_df['columns'].keys()) == expected_columns
+        assert list(polars_df['data'].dtype.names) == expected_columns
 
     def test_to_pandas_raises_helpful_error_when_pandas_missing(self, monkeypatch):
         """Test that to_pandas raises ImportError with helpful guidance."""

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -493,6 +493,65 @@ class TestSimulationDataFrameConverters:
         assert self._get_value(polars_df, 0, 'MainGate') == 2.0
         assert self._get_value(polars_df, 1, 'spill') == 1.0
 
+    def test_converters_preserve_schema_for_empty_results(self):
+        """Test empty structured arrays preserve dtype schema columns in converters."""
+        from canteen.simulation import to_pandas, to_polars
+        import sys
+        import types
+
+        result = np.array(
+            [],
+            dtype=[
+                ('timestep', np.int32),
+                ('timestamp', 'datetime64[D]'),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('MainGate', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        def _pandas_dataframe(columns):
+            """Return columns payload for assertion-friendly fake dataframe behavior."""
+            return {'columns': columns}
+
+        def _polars_dataframe(columns):
+            """Return columns payload for assertion-friendly fake dataframe behavior."""
+            return {'columns': columns}
+
+        old_pandas = sys.modules.get("pandas")
+        old_polars = sys.modules.get("polars")
+        fake_pd = types.ModuleType("pandas")
+        fake_pd.DataFrame = _pandas_dataframe
+        fake_pl = types.ModuleType("polars")
+        fake_pl.DataFrame = _polars_dataframe
+
+        sys.modules["pandas"] = fake_pd
+        sys.modules["polars"] = fake_pl
+        try:
+            pandas_df = to_pandas(result)
+            polars_df = to_polars(result)
+        finally:
+            if old_pandas is None:
+                del sys.modules["pandas"]
+            else:
+                sys.modules["pandas"] = old_pandas
+            if old_polars is None:
+                del sys.modules["polars"]
+            else:
+                sys.modules["polars"] = old_polars
+
+        expected_columns = [
+            'timestep',
+            'timestamp',
+            'inflow',
+            'storage',
+            'MainGate',
+            'spill',
+        ]
+        assert list(pandas_df['columns'].keys()) == expected_columns
+        assert list(polars_df['columns'].keys()) == expected_columns
+
     def test_to_pandas_raises_helpful_error_when_pandas_missing(self, monkeypatch):
         """Test that to_pandas raises ImportError with helpful guidance."""
         import pytest

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -312,3 +312,195 @@ class TestSimulateValidation:
         # Result should be returned successfully
         assert result is not None
         assert len(result) == 3
+
+
+class TestSimulationDataFrameConverters:
+    """Test structured-array to DataFrame converter helpers."""
+
+    def test_to_pandas_converts_structured_array_to_dataframe(self):
+        """Test that to_pandas converts simulation result to pandas DataFrame."""
+        from canteen.simulation import to_pandas
+        import sys
+        import types
+
+        result = np.array(
+            [(0, 10.0, 50.0, 0.0), (1, 20.0, 70.0, 0.0)],
+            dtype=[
+                ('timestep', np.int32),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        def _dataframe(rows):
+            """Return rows payload for assertion-friendly fake dataframe behavior."""
+            return {'rows': rows}
+
+        monkey_module = types.ModuleType("pandas")
+        monkey_module.DataFrame = _dataframe
+        old_pandas = sys.modules.get("pandas")
+        sys.modules["pandas"] = monkey_module
+        try:
+            converted = to_pandas(result)
+        finally:
+            if old_pandas is None:
+                del sys.modules["pandas"]
+            else:
+                sys.modules["pandas"] = old_pandas
+
+        assert isinstance(converted, dict)
+        assert len(converted['rows']) == 2
+        assert converted['rows'][0]['timestep'] == 0
+        assert converted['rows'][1]['storage'] == 70.0
+
+    def test_to_polars_converts_structured_array_to_dataframe(self):
+        """Test that to_polars converts simulation result to polars DataFrame."""
+        from canteen.simulation import to_polars
+        import sys
+        import types
+
+        result = np.array(
+            [(0, 10.0, 50.0, 0.0), (1, 20.0, 70.0, 5.0)],
+            dtype=[
+                ('timestep', np.int32),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        def _dataframe(rows):
+            """Return rows payload for assertion-friendly fake dataframe behavior."""
+            return {'rows': rows}
+
+        monkey_module = types.ModuleType("polars")
+        monkey_module.DataFrame = _dataframe
+        old_polars = sys.modules.get("polars")
+        sys.modules["polars"] = monkey_module
+        try:
+            converted = to_polars(result)
+        finally:
+            if old_polars is None:
+                del sys.modules["polars"]
+            else:
+                sys.modules["polars"] = old_polars
+
+        assert isinstance(converted, dict)
+        assert len(converted['rows']) == 2
+        assert converted['rows'][0]['inflow'] == 10.0
+        assert converted['rows'][1]['spill'] == 5.0
+
+    def test_converters_handle_results_with_outlet_columns_and_timestamps(self):
+        """Test converter compatibility with richer simulation schemas."""
+        from canteen.simulation import to_pandas, to_polars
+        import sys
+        import types
+
+        result = np.array(
+            [
+                (0, np.datetime64('2026-01-01'), 10.0, 50.0, 2.0, 0.0),
+                (1, np.datetime64('2026-01-02'), 20.0, 68.0, 3.0, 1.0),
+            ],
+            dtype=[
+                ('timestep', np.int32),
+                ('timestamp', 'datetime64[D]'),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('MainGate', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        def _dataframe(rows):
+            """Return rows payload for assertion-friendly fake dataframe behavior."""
+            return {'rows': rows}
+
+        old_pandas = sys.modules.get("pandas")
+        old_polars = sys.modules.get("polars")
+        fake_pd = types.ModuleType("pandas")
+        fake_pd.DataFrame = _dataframe
+        fake_pl = types.ModuleType("polars")
+        fake_pl.DataFrame = _dataframe
+
+        sys.modules["pandas"] = fake_pd
+        sys.modules["polars"] = fake_pl
+        try:
+            pandas_df = to_pandas(result)
+            polars_df = to_polars(result)
+        finally:
+            if old_pandas is None:
+                del sys.modules["pandas"]
+            else:
+                sys.modules["pandas"] = old_pandas
+            if old_polars is None:
+                del sys.modules["polars"]
+            else:
+                sys.modules["polars"] = old_polars
+
+        assert pandas_df['rows'][0]['timestamp'] == np.datetime64('2026-01-01')
+        assert pandas_df['rows'][1]['MainGate'] == 3.0
+        assert polars_df['rows'][0]['MainGate'] == 2.0
+        assert polars_df['rows'][1]['spill'] == 1.0
+
+    def test_to_pandas_raises_helpful_error_when_pandas_missing(self):
+        """Test that to_pandas raises ImportError with helpful guidance."""
+        import builtins
+        import pytest
+
+        from canteen.simulation import to_pandas
+
+        result = np.array(
+            [(0, 10.0, 50.0, 0.0)],
+            dtype=[
+                ('timestep', np.int32),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "pandas":
+                raise ImportError("No module named pandas")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _fake_import
+        try:
+            with pytest.raises(ImportError, match="pandas"):
+                to_pandas(result)
+        finally:
+            builtins.__import__ = real_import
+
+    def test_to_polars_raises_helpful_error_when_polars_missing(self):
+        """Test that to_polars raises ImportError with helpful guidance."""
+        import builtins
+        import pytest
+
+        from canteen.simulation import to_polars
+
+        result = np.array(
+            [(0, 10.0, 50.0, 0.0)],
+            dtype=[
+                ('timestep', np.int32),
+                ('inflow', np.float64),
+                ('storage', np.float64),
+                ('spill', np.float64),
+            ],
+        )
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "polars":
+                raise ImportError("No module named polars")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _fake_import
+        try:
+            with pytest.raises(ImportError, match="polars"):
+                to_polars(result)
+        finally:
+            builtins.__import__ = real_import

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,14 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "appnope"
@@ -38,6 +46,16 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dataframe = [
+    { name = "pandas" },
+    { name = "polars" },
+]
+pandas = [
+    { name = "pandas" },
+]
+polars = [
+    { name = "polars" },
+]
 units = [
     { name = "units" },
 ]
@@ -55,9 +73,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=2.4.4" },
+    { name = "pandas", marker = "extra == 'dataframe'", specifier = ">=2.2.0" },
+    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.0" },
+    { name = "polars", marker = "extra == 'dataframe'", specifier = ">=1.0.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0.0" },
     { name = "units", marker = "extra == 'units'", git = "https://github.com/JohnRushKucharski/units" },
 ]
-provides-extras = ["units"]
+provides-extras = ["units", "pandas", "polars", "dataframe"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -498,6 +520,50 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -520,7 +586,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -543,6 +609,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]
@@ -817,6 +911,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Added simulation result converter helpers for pandas and polars as top-level functions in the simulation module. The converters accept numpy structured-array output from simulate(), preserve all schema columns (including optional outlet columns and timestamps), and lazily import optional dependencies with clear installation guidance when missing.

## Changes

- Added to_pandas(result) and to_polars(result) in src/canteen/simulation.py
- Added shared structured-array row conversion helper for schema-agnostic conversion
- Added tests for pandas/polars conversion, richer schemas, and graceful missing-dependency errors

## Acceptance criteria

- [x] to_pandas() converts structured array to pandas DataFrame
- [x] to_polars() converts to polars DataFrame
- [x] Works with various result schemas (with/without outlets, timestamps)
- [x] Graceful error if pandas/polars not installed
- [x] Tests: converters, schema handling

Closes #23

## Remaining issues

None.