### PR TITLE
fix(#56): [Plugin Arch] Child A: plugin utils skeleton + kill switch

### DIFF
--- a/src/canteen/_plugin_utils.py
+++ b/src/canteen/_plugin_utils.py
@@ -1,0 +1,12 @@
+"""Shared plugin utility helpers for file-based plugin discovery."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _is_file_plugins_disabled() -> bool:
+    """Return whether file plugin discovery is disabled via environment."""
+    raw_value = os.getenv("CANTEEN_DISABLE_FILE_PLUGINS", "")
+    return raw_value.strip().lower() in {"1", "true", "yes"}

--- a/src/canteen/_plugin_utils.py
+++ b/src/canteen/_plugin_utils.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _is_file_plugins_disabled() -> bool:

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,0 +1,28 @@
+"""Tests for shared plugin utility helpers."""
+
+import pytest
+
+from canteen._plugin_utils import _is_file_plugins_disabled
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YeS"])
+def test_is_file_plugins_disabled_true_values(monkeypatch, value):
+    """Kill switch should disable file plugins for accepted true values."""
+    monkeypatch.setenv("CANTEEN_DISABLE_FILE_PLUGINS", value)
+
+    assert _is_file_plugins_disabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "", "unexpected"])
+def test_is_file_plugins_disabled_false_values(monkeypatch, value):
+    """Kill switch should remain off for non-true values."""
+    monkeypatch.setenv("CANTEEN_DISABLE_FILE_PLUGINS", value)
+
+    assert _is_file_plugins_disabled() is False
+
+
+def test_is_file_plugins_disabled_false_when_unset(monkeypatch):
+    """Kill switch defaults to off when the variable is missing."""
+    monkeypatch.delenv("CANTEEN_DISABLE_FILE_PLUGINS", raising=False)
+
+    assert _is_file_plugins_disabled() is False

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -6,7 +6,9 @@ from canteen._plugin_utils import _is_file_plugins_disabled
 
 
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YeS"])
-def test_is_file_plugins_disabled_true_values(monkeypatch, value):
+def test_is_file_plugins_disabled_true_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
     """Kill switch should disable file plugins for accepted true values."""
     monkeypatch.setenv("CANTEEN_DISABLE_FILE_PLUGINS", value)
 
@@ -14,14 +16,18 @@ def test_is_file_plugins_disabled_true_values(monkeypatch, value):
 
 
 @pytest.mark.parametrize("value", ["0", "false", "no", "", "unexpected"])
-def test_is_file_plugins_disabled_false_values(monkeypatch, value):
+def test_is_file_plugins_disabled_false_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
     """Kill switch should remain off for non-true values."""
     monkeypatch.setenv("CANTEEN_DISABLE_FILE_PLUGINS", value)
 
     assert _is_file_plugins_disabled() is False
 
 
-def test_is_file_plugins_disabled_false_when_unset(monkeypatch):
+def test_is_file_plugins_disabled_false_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Kill switch defaults to off when the variable is missing."""
     monkeypatch.delenv("CANTEEN_DISABLE_FILE_PLUGINS", raising=False)
 


### PR DESCRIPTION
## Summary

Implemented the shared plugin utility module skeleton and the file-plugin discovery kill switch helper for the plugin architecture tracer bullet.

## Changes

- Added src/canteen/_plugin_utils.py with module docstring and logger setup
- Implemented _is_file_plugins_disabled() -> bool using CANTEEN_DISABLE_FILE_PLUGINS
- Added focused tests in 	ests/test_plugin_utils.py for true/false/unset environment behavior
- Accepted true values are 1, 	rue, and yes (case-insensitive)

## Acceptance criteria

- [x] Add src/canteen/_plugin_utils.py with module docstring and logger setup
- [x] Add _is_file_plugins_disabled() -> bool that checks CANTEEN_DISABLE_FILE_PLUGINS
- [x] Treat values 1, 	rue, and yes (case-insensitive) as disabled
- [x] Add focused tests for kill-switch true/false behavior
- [x] Keep all new symbols fully type-annotated

Closes #56

## Remaining issues

None.